### PR TITLE
Add the desktop interface to allow xdg-open to work.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
   matterhorn:
     command: matterhorn
     plugs:
+      - desktop
       - network
       - password-manager-service
 


### PR DESCRIPTION
This allows you to open URLs from matterhorn.