### PR TITLE
patches: Don't call notify-send twice

### DIFF
--- a/patches/notify-add-snap-parameters.patch
+++ b/patches/notify-add-snap-parameters.patch
@@ -9,12 +9,12 @@
  
  # Escape backslashes in the message
  message="${message//\\/\\\\}"
-@@ -62,5 +62,8 @@
+@@ -62,5 +62,7 @@
  if [ ! -z "$urgency" ]
  then
      test "$urgency" = "none" ||
+-        notify-send -u "$urgency" -c "$notify_CATEGORY" -- "$notify_HEAD" "$notify_BODY"
 +        notify-send -i $SNAP/meta/gui/${SNAP_NAME}.png \
 +            -h "string:desktop-entry:${SNAP_NAME}_${SNAP_NAME}" \
 +            -u "$urgency" -c "$notify_CATEGORY" -- "$notify_HEAD" "$notify_BODY"
-         notify-send -u "$urgency" -c "$notify_CATEGORY" -- "$notify_HEAD" "$notify_BODY"
  fi


### PR DESCRIPTION
The default command was left around by mistake, even if the shell was
ignoring it, we should not call `notify-send` twice