### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,9 +21,6 @@ apps:
       - x11
 
 parts:
-  build-trigger:
-    plugin: nil
-    source: https://github.com/matterhorn-chat/matterhorn.git
   matterhorn:
     plugin: nil
     override-build: |


### PR DESCRIPTION
Ok, now I remember why I removed the build trigger previously, whoops. It fails to build due to git urls which the build machine can't get to.