### PR TITLE
snapcraft: Compile matterhorn from upstream sources and migrate to core20

### DIFF
--- a/patches/do-not-override-jobs-in-build.patch
+++ b/patches/do-not-override-jobs-in-build.patch
@@ -1,0 +1,10 @@
+diff --git a/build.sh b/build.sh
+index c3091195..485c9204 100755
+--- a/build.sh
++++ b/build.sh
+@@ -7,4 +7,4 @@ set -e
+ 
+ HERE=$(cd `dirname $0`; pwd)
+ cd $HERE
+-cabal new-build -j --enable-tests
++cabal new-build --enable-tests

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,9 +7,6 @@ description: |
 grade: stable
 confinement: strict
 
-architectures:
-  - build-on: amd64
-
 apps:
   matterhorn:
     command: matterhorn
@@ -37,10 +34,14 @@ parts:
         (cd "${SNAPCRAFT_PART_SRC}" && patch -p1 < "$p")
       done
 
-      add-apt-repository -y ppa:hvr/ghc
-      apt-get update && apt-get install -y cabal-install-3.0 ghc-8.8.4
+      add-apt-repository -y ppa:hvr/ghc && apt-get update
 
-      export PATH=/opt/ghc/bin/:$PATH
+      if apt-get install -y cabal-install-3.0 ghc-8.8.4; then
+        export PATH=/opt/ghc/bin/:$PATH
+      else
+        cabal -j${SNAPCRAFT_PARALLEL_BUILD_COUNT} install cabal-install
+      fi
+
       cabal -j${SNAPCRAFT_PARALLEL_BUILD_COUNT} new-update
     override-build: |
       set -eu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,33 +22,50 @@ apps:
 
 parts:
   matterhorn:
+    source: https://github.com/matterhorn-chat/matterhorn.git
+    source-branch: develop
     plugin: nil
+    override-pull: |
+      # FIXME: We need a way to make snapcraft not to use --recursive, but
+      # We keep the source and branch stuff for future and to get git deps
+      # snapcraftctl pull
+      git clone https://github.com/matterhorn-chat/matterhorn.git -b develop ${SNAPCRAFT_PART_SRC}
+
+      sed -i -e /url/s,git@github.com:,https://github.com/, ${SNAPCRAFT_PART_SRC}/.gitmodules
+      git -C ${SNAPCRAFT_PART_SRC} submodule update --init
+      for p in "${SNAPCRAFT_PROJECT_DIR}"/patches/*; do
+        (cd "${SNAPCRAFT_PART_SRC}" && patch -p1 < "$p")
+      done
+
+      add-apt-repository -y ppa:hvr/ghc
+      apt-get update && apt-get install -y cabal-install-3.0 ghc-8.8.4
+
+      export PATH=/opt/ghc/bin/:$PATH
+      cabal -j${SNAPCRAFT_PARALLEL_BUILD_COUNT} new-update
     override-build: |
       set -eu
-      ARCHITECTURE=$(dpkg --print-architecture)
-      echo "Get GitHub releases..."
-      wget --quiet https://api.github.com/repos/matterhorn-chat/matterhorn/releases -O releases.json
-      VERSION=$(jq -r '[.[].tag_name][0]' releases.json)
-      TAR_URL=$(jq -r '[.[].assets[] | select(.name | contains("ubuntu")) | select(.name | contains(".tar.")).browser_download_url ][0]' releases.json)
-      TAR=$(basename "${TAR_URL}")
-      echo "Downloading ${TAR_URL}..."
-      wget "${TAR_URL}" -O "${SNAPCRAFT_PART_INSTALL}/${TAR}"
+      export PATH=/opt/ghc/bin/:$PATH
+      export CABALARGS="-j${SNAPCRAFT_PARALLEL_BUILD_COUNT}"
+      export LANG=C.UTF-8
+
+      cd "${SNAPCRAFT_PART_BUILD}"
+      ./scripts/local-mkrelease.sh
+
+      TAR=$(ls matterhorn-*.tar.* -1)
       echo "Unpacking ${TAR}..."
       mkdir -p "${SNAPCRAFT_PART_INSTALL}/app"
-      tar jxvf "${SNAPCRAFT_PART_INSTALL}/${TAR}" -C "${SNAPCRAFT_PART_INSTALL}/app" --strip-components=1
-      for p in "$PWD"/patches/*; do
-        (cd "${SNAPCRAFT_PART_INSTALL}/app" && patch -p1 < $p)
-      done
-      install -m 755 launcher -D ${SNAPCRAFT_PART_INSTALL}/bin/matterhorn -v
-      rm -f releases.json
-      rm -f "${SNAPCRAFT_PART_INSTALL}/${TAR}"
-      snapcraftctl set-version "$VERSION"
-    source: .
+      tar jxvf "${TAR}" -C "${SNAPCRAFT_PART_INSTALL}/app" --strip-components=1
+      install -m 755 ${SNAPCRAFT_PROJECT_DIR}/launcher -D ${SNAPCRAFT_PART_INSTALL}/bin/matterhorn -v
+      rm -f "${TAR}"
+
+      snapcraftctl set-version "$(git describe --tags)"
     build-packages:
-      - wget
-      - jq
+      # Ubuntu's default can be enabled on core20, as cabal provides new-{update,build}
+      # - cabal-install
+      # - ghc
+      - software-properties-common
+      - zlib1g-dev
     stage-packages:
       - libsecret-tools
       - libnotify-bin
       - xclip
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: matterhorn
-base: core18
+base: core20
 adopt-info: matterhorn
 summary: Matterhorn
 description: |
@@ -9,7 +9,7 @@ confinement: strict
 
 apps:
   matterhorn:
-    command: matterhorn
+    command: bin/matterhorn
     plugs:
       - home
       - desktop
@@ -34,20 +34,11 @@ parts:
         (cd "${SNAPCRAFT_PART_SRC}" && patch -p1 < "$p")
       done
 
-      add-apt-repository -y ppa:hvr/ghc && apt-get update
-
-      if apt-get install -y cabal-install-3.0 ghc-8.8.4; then
-        export PATH=/opt/ghc/bin/:$PATH
-      else
-        cabal -j${SNAPCRAFT_PARALLEL_BUILD_COUNT} install cabal-install
-      fi
-
       cabal -j${SNAPCRAFT_PARALLEL_BUILD_COUNT} new-update
     override-build: |
       set -eu
-      export PATH=/opt/ghc/bin/:$PATH
-      export CABALARGS="-j${SNAPCRAFT_PARALLEL_BUILD_COUNT}"
       export LANG=C.UTF-8
+      export CABALARGS="-j${SNAPCRAFT_PARALLEL_BUILD_COUNT}"
 
       cd "${SNAPCRAFT_PART_BUILD}"
       ./scripts/local-mkrelease.sh
@@ -61,12 +52,11 @@ parts:
 
       snapcraftctl set-version "$(git describe --tags)"
     build-packages:
-      # Ubuntu's default can be enabled on core20, as cabal provides new-{update,build}
-      # - cabal-install
-      # - ghc
-      - software-properties-common
+      - cabal-install
+      - ghc
       - zlib1g-dev
     stage-packages:
+      - libatomic1
       - libsecret-tools
       - libnotify-bin
       - xclip


### PR DESCRIPTION
Use upstream develop branch as base source, so that we can have a proper
edge snap channel open with all the upstream git changes.

New releases will also be included in the same branch but the version
will not include the `-g${SHA}` suffix so will be easy to spot.

Since we use core18, and given that the `cabal` provided by bionic isn't
enough to compile matterhorn, I'm using the same PPA that upstream is
using to get both cabal and ghc.

Alternatively it could be possible to install new cabal with just `cabal
install cabal-install` but this would lead to compiling more components
that would slow-down the building time, and this is quite unneeded since
upstream-trusted build-depends binaries exist.

The ppa usage can be reverted once we'll be in core20.

Compiling this with snapcraft + multipass requires more RAM than you're
generally given, so `SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=4G` or similar env
variable should be passed when the multipass VM is created.