### PR TITLE
patches: Use absolute path for notify icon

### DIFF
--- a/patches/notify-add-snap-parameters.patch
+++ b/patches/notify-add-snap-parameters.patch
@@ -14,7 +14,7 @@
  then
      test "$urgency" = "none" ||
 -        notify-send -u "$urgency" -c "$notify_CATEGORY" -- "$notify_HEAD" "$notify_BODY"
-+        notify-send -i $SNAP/meta/gui/${SNAP_NAME}.png \
++        notify-send -i /meta/gui/${SNAP_NAME}.png \
 +            -h "string:desktop-entry:${SNAP_NAME}_${SNAP_NAME}" \
 +            -u "$urgency" -c "$notify_CATEGORY" -- "$notify_HEAD" "$notify_BODY"
  fi


### PR DESCRIPTION
In core20 we include new libnotify that tries to convert absolute paths
to snap paths, it looks buggy though if the path already contains a
$SNAP component, so just pass the absolute one and leave libnotify do
the rest.

---

Without this in current edge there's no icon in the notifications